### PR TITLE
Optimize release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,12 @@ readme = "README.md"
 license = "MPL-2.0"
 keywords = ["minecraft", "mod-manager", "modrinth", "curseforge", "github"]
 
+# Optimize for speed and binary size on release builds
+[profile.release]
+codegen-units = 1
+lto = true
+strip = true
+
 [features]
 default = ["gtk"]
 gtk = ["libium/gtk"]


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/57120300/171689639-d298f792-aac7-4248-a2c7-b77d34055e29.png)

After:
![image](https://user-images.githubusercontent.com/57120300/171690781-738607fa-7660-4e79-93ac-5d20b026a3d0.png)

This already seems to be done on github releases but it might as well be done on all release builds