### PR TITLE
Set the config location with an environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/.idea
 /out
 /tests/configs/.json
 /tests/configs/running

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,10 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
         "$2a$10$QbCxI6f4KxEs50QKwE2piu1t6oOA8ayOw27H9N/eaH3Sdp5NTWwvO",
     ));
     let mut config_file =
-        config::get_file(cli_app.config_file.unwrap_or_else(config::file_path)).await?;
+        config::get_file(cli_app.config_file
+            .or_else(|| std::env::var_os("FERIUM_CONFIG_LOCATION")
+                .map(|str| str.into()))
+            .unwrap_or_else(config::file_path)).await?;
     let mut config = config::deserialise(&config::read_file(&mut config_file).await?)?;
 
     // Run function(s) based on the sub(sub)command to be executed

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
     let mut config_file =
         config::get_file(cli_app.config_file
             .or_else(|| std::env::var_os("FERIUM_CONFIG_LOCATION")
-                .map(|str| str.into()))
+                .map(Into::into))
             .unwrap_or_else(config::file_path)).await?;
     let mut config = config::deserialise(&config::read_file(&mut config_file).await?)?;
 


### PR DESCRIPTION
With this pull request ferium can additionally use the `FERIUM_CONFIG_LOCATION` environment variable  the determine where it should put it's config file.

The benefit of using an env var instead of the `--config-file <CONFIG_FILE>` option is that a env var persists for the entire shell session which means that instead of doing this:
```bash
ferium --config-file "/long/path/to/my/config/file/location/config.json" add mod1
ferium --config-file "/long/path/to/my/config/file/location/config.json" add mod2
ferium --config-file "/long/path/to/my/config/file/location/config.json" add mod3
ferium --config-file "/long/path/to/my/config/file/location/config.json" add mod4
ferium --config-file "/long/path/to/my/config/file/location/config.json" add mod5
``` 
one can simply do this:
```bash
export FERIUM_CONFIG_LOCATION="/long/path/to/my/config/file/location/config.json"
ferium add mod1
ferium add mod2
ferium add mod3
ferium add mod4
ferium add mod5
```