### PR TITLE
Upgrade dependency size to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
  "reqwest",
  "semver",
  "serde_json",
- "size",
+ "size 0.4.0",
  "tokio",
  "url",
 ]
@@ -1324,7 +1324,7 @@ dependencies = [
  "rfd",
  "serde",
  "serde_json",
- "size",
+ "size 0.2.0",
  "thiserror",
  "tokio",
  "url",
@@ -2117,6 +2117,12 @@ checksum = "4fb3f61ca4410df5894add0b47d4d2c882c837dfa660d579c9b3fd29b1ce3a0e"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "size"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c9c8350184b6b037d09dc77df55f1324df076a706d0191b79ec270cc4d756b"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ semver = "~1.0.10"
 online = "~3.0.1"
 bytes = "~1.1.0"
 furse = "~1.4.0"
-size = "~0.2.0"
+size = "~0.4.0"
 url = "~2.2.2"
 
 [dev-dependencies]

--- a/src/download.rs
+++ b/src/download.rs
@@ -8,7 +8,7 @@ use fs_extra::{
 use indicatif::ProgressBar;
 use itertools::Itertools;
 use libium::{mutex_ext::MutexExt, upgrade::Downloadable};
-use size::{Base, Style};
+use size::Base;
 use std::{
     ffi::OsString,
     fs::read_dir,
@@ -129,7 +129,7 @@ pub async fn download(
                 "{} Downloaded {:7} {}",
                 &*TICK,
                 match size {
-                    Some(size) => size.to_string(Base::Base10, Style::Smart),
+                    Some(size) => size.format().with_base(Base::Base10),
                     None => String::new(),
                 },
                 filename.dimmed(),


### PR DESCRIPTION
`size` 0.4 uses the builder pattern for manually formatting sizes so that only the
parameters you wish to change (in this case, `Base` but not `Style`) need to be
listed.

This patch should only be merged after gorilla-devs/libium#8 is merged and this
crate is updated to use that release of libium, to keep the `size` crates
aligned.

(I do not expect any more breaking changes to `size` anytime soon!)