### PR TITLE
Adds ARM64 Linux Builds and Switch to Musl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,27 +39,40 @@ jobs:
         with:
           toolchain: stable
           target: x86_64-pc-windows-gnu
-      - name: Install Rust for Linux ARM64
+      - name: Install Musl Rust target
         if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: aarch64-unknown-linux-gnu
-
+          target: x86_64-unknown-linux-musl
+      - name: Install Musl Rust for Linux ARM64
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-musl
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64 musl musl-tools gcc-aarch64-linux-gnu
 
       - name: Lint code
         run: just lint
 
       - name: Run tests
+        if: matrix.os != 'ubuntu-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test
-
+          
+      - name: Run Musl tests
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --target=x86_64-unknown-linux-musl
+          
       - name: Build macOS
         if: matrix.os == 'macos-latest'
         run: |
@@ -71,12 +84,12 @@ jobs:
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
-          just build-linux-nogui
-          just build-linux-gtk
-          just build-linux-xdg
-          just build-linux-arm64-nogui
-          just build-linux-arm64-gtk
-          just build-linux-arm64-xdg
+          just build-linux-gtk-musl
+          just build-linux-nogui-musl
+          just build-linux-xdg-musl
+          just build-linux-arm64-gtk-musl
+          just build-linux-arm64-nogui-musl
+          just build-linux-arm64-xdg-musl
           just build-win-gnu
 
       - name: Upload build artefacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -34,44 +34,47 @@ jobs:
         with:
           toolchain: stable
       - name: Install Rust for Linux
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: x86_64-pc-windows-gnu
       - name: Install Musl Rust target
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: x86_64-unknown-linux-musl
       - name: Install Musl Rust for Linux ARM64
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: aarch64-unknown-linux-musl
       - name: Install Linux dependencies
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64 musl musl-tools gcc-aarch64-linux-gnu clang llvm
+          # install clang-14 on focal
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 14
+          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64 musl musl-tools gcc-aarch64-linux-gnu
 
       - name: Lint code
         run: just lint
 
       - name: Run tests
-        if: matrix.os != 'ubuntu-22.04'
         uses: actions-rs/cargo@v1
         with:
           command: test
 
       - name: Run Musl tests
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --target=x86_64-unknown-linux-musl
+          args: --target=x86_64-unknown-linux-musl --no-default-features --features xdg
 
       - name: Build macOS
         if: matrix.os == 'macos-latest'
@@ -82,14 +85,13 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: just build-win
       - name: Build Linux
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-latest'
         run: |
-          just build-linux-gtk-musl
+          just build-linux-gtk
           just build-linux-nogui-musl
           just build-linux-xdg-musl
-          just build-linux-arm64-gtk-musl
           just build-linux-arm64-nogui-musl
-          just build-linux-arm64-xdg-musl          
+          just build-linux-arm64-xdg-musl
           just build-win-gnu
 
       - name: Upload build artefacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,18 @@ jobs:
         with:
           toolchain: stable
           target: x86_64-pc-windows-gnu
+      - name: Install Rust for Linux ARM64
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
 
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64
+          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64 gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
       - name: Lint code
         run: just lint
@@ -68,6 +74,9 @@ jobs:
           just build-linux-nogui
           just build-linux-gtk
           just build-linux-xdg
+          just build-linux-arm64-nogui
+          just build-linux-arm64-gtk
+          just build-linux-arm64-xdg
           just build-win-gnu
 
       - name: Upload build artefacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -34,45 +34,45 @@ jobs:
         with:
           toolchain: stable
       - name: Install Rust for Linux
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: x86_64-pc-windows-gnu
       - name: Install Musl Rust target
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: x86_64-unknown-linux-musl
       - name: Install Musl Rust for Linux ARM64
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: aarch64-unknown-linux-musl
       - name: Install Linux dependencies
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64 musl musl-tools gcc-aarch64-linux-gnu
+          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64 musl musl-tools gcc-aarch64-linux-gnu clang llvm
 
       - name: Lint code
         run: just lint
 
       - name: Run tests
-        if: matrix.os != 'ubuntu-latest'
+        if: matrix.os != 'ubuntu-22.04'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          
+
       - name: Run Musl tests
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --target=x86_64-unknown-linux-musl
-          
+
       - name: Build macOS
         if: matrix.os == 'macos-latest'
         run: |
@@ -82,14 +82,14 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: just build-win
       - name: Build Linux
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           just build-linux-gtk-musl
           just build-linux-nogui-musl
           just build-linux-xdg-musl
           just build-linux-arm64-gtk-musl
           just build-linux-arm64-nogui-musl
-          just build-linux-arm64-xdg-musl
+          just build-linux-arm64-xdg-musl          
           just build-win-gnu
 
       - name: Upload build artefacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
             - GNU Linux (x64 linux gnu) with GTK backend for GNOME
             - GNU Linux (x64 linux gnu) without a GUI file dialogue and libraries
             - GNU Linux (x64 linux gnu) with XDG backend for XDG Desktop Portal
+            - GNU Linux (aarch64 linux gnu) with GTK backend for GNOME
+            - GNU Linux (aarch64 linux gnu) without a GUI file dialogue and libraries
+            - GNU Linux (aarch64 linux gnu) with XDG backend for XDG Desktop Portal
             - macOS Apple Silicon (aarch64 darwin)
             - macOS Intel (x64 darwin)
             - GNU Windows, i.e. Cygwin/MinGW (x64 windows gnu)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Download artefacts
+      - name: Download artifacts
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow_conclusion: success
@@ -51,13 +51,12 @@ jobs:
             Compiled binaries for Ferium version `${{ github.ref_name }}` ([changelog](https://github.com/gorilla-devs/ferium/blob/main/CHANGELOG.md#${{ env.MD_HEADER }}))
 
             The provided binaries are for:
-
-            - GNU Linux (x64 linux gnu) with GTK backend for GNOME
-            - GNU Linux (x64 linux gnu) without a GUI file dialogue and libraries
-            - GNU Linux (x64 linux gnu) with XDG backend for XDG Desktop Portal
-            - GNU Linux (aarch64 linux gnu) with GTK backend for GNOME
-            - GNU Linux (aarch64 linux gnu) without a GUI file dialogue and libraries
-            - GNU Linux (aarch64 linux gnu) with XDG backend for XDG Desktop Portal
+            - Linux (x64 linux) with GTK backend for GNOME
+            - Linux (x64 linux) without a GUI file dialogue and libraries
+            - Linux (x64 linux) with XDG Desktop Portal backend
+            - Linux (aarch64 linux) with GTK backend for GNOME
+            - Linux (aarch64 linux) without a GUI file dialogue and libraries
+            - Linux (aarch64 linux) with XDG backend for XDG Desktop Portal
             - macOS Apple Silicon (aarch64 darwin)
             - macOS Intel (x64 darwin)
             - GNU Windows, i.e. Cygwin/MinGW (x64 windows gnu)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,11 @@ jobs:
             Compiled binaries for Ferium version `${{ github.ref_name }}` ([changelog](https://github.com/gorilla-devs/ferium/blob/main/CHANGELOG.md#${{ env.MD_HEADER }}))
 
             The provided binaries are for:
-            - Linux (x64 linux) with GTK backend for GNOME
+            - Linux (x64 linux) with GTK backend for GNOME (Deprecated Dynamic Binary)
             - Linux (x64 linux) without a GUI file dialogue and libraries
             - Linux (x64 linux) with XDG Desktop Portal backend
-            - Linux (aarch64 linux) with GTK backend for GNOME
             - Linux (aarch64 linux) without a GUI file dialogue and libraries
-            - Linux (aarch64 linux) with XDG backend for XDG Desktop Portal
+            - Linux (aarch64 linux) with XDG Desktop Portal backend
             - macOS Apple Silicon (aarch64 darwin)
             - macOS Intel (x64 darwin)
             - GNU Windows, i.e. Cygwin/MinGW (x64 windows gnu)

--- a/justfile
+++ b/justfile
@@ -50,6 +50,27 @@ build-linux-nogui:
     cargo build --target=x86_64-unknown-linux-gnu --release --no-default-features
     zip -r out/ferium-linux-gnu-nogui.zip -j target/x86_64-unknown-linux-gnu/release/ferium
 
+# Build for GNU Linux ARM64 with a GTK backend
+build-linux-arm64-gtk:
+    rm -f out/ferium-linux-gnu-arm64-gtk.zip
+    mkdir -p out
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-gnu --release
+    zip -r out/ferium-linux-gnu-arm64-gtk.zip -j target/aarch64-unknown-linux-gnu/release/ferium
+
+# Build for GNU Linux ARM64 with an XDG backend
+build-linux-arm64-xdg:
+    rm -f out/ferium-linux-gnu-arm64-xdg.zip
+    mkdir -p out
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-gnu --release --no-default-features --features xdg
+    zip -r out/ferium-linux-gnu-arm64-xdg.zip -j target/aarch64-unknown-linux-gnu/release/ferium
+
+# Build for GNU Linux ARM64 without a GUI backend
+build-linux-arm64-nogui:
+    rm -f out/ferium-linux-gnu-arm64-nogui.zip
+    mkdir -p out
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-gnu --release --no-default-features
+    zip -r out/ferium-linux-gnu-arm64-nogui.zip -j target/aarch64-unknown-linux-gnu/release/ferium
+
 # Run clippy lints
 lint:
     cargo clippy --   \

--- a/justfile
+++ b/justfile
@@ -70,7 +70,49 @@ build-linux-arm64-nogui:
     mkdir -p out
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-gnu --release --no-default-features
     zip -r out/ferium-linux-gnu-arm64-nogui.zip -j target/aarch64-unknown-linux-gnu/release/ferium
+    
+# Build for Musl Linux with a GTK backend
+build-linux-gtk-musl:
+    rm -f out/ferium-linux-musl-gtk.zip
+    mkdir -p out
+    cargo build --target=x86_64-unknown-linux-musl --release
+    zip -r out/ferium-linux-musl-gtk.zip -j target/x86_64-unknown-linux-musl/release/ferium
+    
+# Build for Musl Linux with an XDG backend
+build-linux-xdg-musl:
+    rm -f out/ferium-linux-musl-xdg.zip
+    mkdir -p out
+    cargo build --target=x86_64-unknown-linux-musl --release --no-default-features --features xdg
+    zip -r out/ferium-linux-musl-xdg.zip -j target/x86_64-unknown-linux-musl/release/ferium
+    
+# Build for Musl Linux without a GUI backend
+build-linux-nogui-musl:
+    rm -f out/ferium-linux-musl-nogui.zip
+    mkdir -p out
+    cargo build --target=x86_64-unknown-linux-musl --release --no-default-features
+    zip -r out/ferium-linux-musl-nogui.zip -j target/x86_64-unknown-linux-musl/release/ferium
 
+# Build for Musl Linux ARM64 with a GTK backend
+build-linux-arm64-gtk-musl:
+    rm -f out/ferium-linux-musl-arm64-gtk.zip
+    mkdir -p out
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-musl --release
+    zip -r out/ferium-linux-musl-arm64-gtk.zip -j target/aarch64-unknown-linux-gnu/release/ferium
+
+# Build for Musl Linux ARM64 with an XDG backend
+build-linux-arm64-xdg-musl:
+    rm -f out/ferium-linux-musl-arm64-xdg.zip
+    mkdir -p out
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-musl --release --no-default-features --features xdg
+    zip -r out/ferium-linux-musl-arm64-xdg.zip -j target/aarch64-unknown-linux-gnu/release/ferium
+
+# Build for Musl Linux ARM64 without a GUI backend
+build-linux-arm64-nogui-musl:
+    rm -f out/ferium-linux-musl-arm64-nogui.zip
+    mkdir -p out
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-musl --release --no-default-features
+    zip -r out/ferium-linux-musl-arm64-nogui.zip -j target/aarch64-unknown-linux-gnu/release/ferium
+    
 # Run clippy lints
 lint:
     cargo clippy --   \

--- a/justfile
+++ b/justfile
@@ -71,13 +71,6 @@ build-linux-arm64-nogui:
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-gnu --release --no-default-features
     zip -r out/ferium-linux-gnu-arm64-nogui.zip -j target/aarch64-unknown-linux-gnu/release/ferium
 
-# Build for Musl Linux with a GTK backend
-build-linux-gtk-musl:
-    rm -f out/ferium-linux-musl-gtk.zip
-    mkdir -p out
-    cargo build --target=x86_64-unknown-linux-musl --release
-    zip -r out/ferium-linux-musl-gtk.zip -j target/x86_64-unknown-linux-musl/release/ferium
-
 # Build for Musl Linux with an XDG backend
 build-linux-xdg-musl:
     rm -f out/ferium-linux-musl-xdg.zip
@@ -92,25 +85,18 @@ build-linux-nogui-musl:
     cargo build --target=x86_64-unknown-linux-musl --release --no-default-features
     zip -r out/ferium-linux-musl-nogui.zip -j target/x86_64-unknown-linux-musl/release/ferium
 
-# Build for Musl Linux ARM64 with a GTK backend
-build-linux-arm64-gtk-musl:
-    rm -f out/ferium-linux-musl-arm64-gtk.zip
-    mkdir -p out
-    CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld" cargo build --target=aarch64-unknown-linux-musl --release
-    zip -r out/ferium-linux-musl-arm64-gtk.zip -j target/aarch64-unknown-linux-musl/release/ferium
-
 # Build for Musl Linux ARM64 with an XDG backend
 build-linux-arm64-xdg-musl:
     rm -f out/ferium-linux-musl-arm64-xdg.zip
     mkdir -p out
-    CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld" cargo build --target=aarch64-unknown-linux-musl --release --no-default-features --features xdg
+    CC_aarch64_unknown_linux_musl=clang-14 AR_aarch64_unknown_linux_musl=llvm-ar-14 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld" cargo build --target=aarch64-unknown-linux-musl --release --no-default-features --features xdg
     zip -r out/ferium-linux-musl-arm64-xdg.zip -j target/aarch64-unknown-linux-musl/release/ferium
 
 # Build for Musl Linux ARM64 without a GUI backend
 build-linux-arm64-nogui-musl:
     rm -f out/ferium-linux-musl-arm64-nogui.zip
     mkdir -p out
-    CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld" cargo build --target=aarch64-unknown-linux-musl --release --no-default-features
+    CC_aarch64_unknown_linux_musl=clang-14 AR_aarch64_unknown_linux_musl=llvm-ar-14 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld" cargo build --target=aarch64-unknown-linux-musl --release --no-default-features
     zip -r out/ferium-linux-musl-arm64-nogui.zip -j target/aarch64-unknown-linux-musl/release/ferium
 
 # Run clippy lints

--- a/justfile
+++ b/justfile
@@ -70,21 +70,21 @@ build-linux-arm64-nogui:
     mkdir -p out
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-gnu --release --no-default-features
     zip -r out/ferium-linux-gnu-arm64-nogui.zip -j target/aarch64-unknown-linux-gnu/release/ferium
-    
+
 # Build for Musl Linux with a GTK backend
 build-linux-gtk-musl:
     rm -f out/ferium-linux-musl-gtk.zip
     mkdir -p out
     cargo build --target=x86_64-unknown-linux-musl --release
     zip -r out/ferium-linux-musl-gtk.zip -j target/x86_64-unknown-linux-musl/release/ferium
-    
+
 # Build for Musl Linux with an XDG backend
 build-linux-xdg-musl:
     rm -f out/ferium-linux-musl-xdg.zip
     mkdir -p out
     cargo build --target=x86_64-unknown-linux-musl --release --no-default-features --features xdg
     zip -r out/ferium-linux-musl-xdg.zip -j target/x86_64-unknown-linux-musl/release/ferium
-    
+
 # Build for Musl Linux without a GUI backend
 build-linux-nogui-musl:
     rm -f out/ferium-linux-musl-nogui.zip
@@ -96,23 +96,23 @@ build-linux-nogui-musl:
 build-linux-arm64-gtk-musl:
     rm -f out/ferium-linux-musl-arm64-gtk.zip
     mkdir -p out
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-musl --release
-    zip -r out/ferium-linux-musl-arm64-gtk.zip -j target/aarch64-unknown-linux-gnu/release/ferium
+    CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld" cargo build --target=aarch64-unknown-linux-musl --release
+    zip -r out/ferium-linux-musl-arm64-gtk.zip -j target/aarch64-unknown-linux-musl/release/ferium
 
 # Build for Musl Linux ARM64 with an XDG backend
 build-linux-arm64-xdg-musl:
     rm -f out/ferium-linux-musl-arm64-xdg.zip
     mkdir -p out
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-musl --release --no-default-features --features xdg
-    zip -r out/ferium-linux-musl-arm64-xdg.zip -j target/aarch64-unknown-linux-gnu/release/ferium
+    CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld" cargo build --target=aarch64-unknown-linux-musl --release --no-default-features --features xdg
+    zip -r out/ferium-linux-musl-arm64-xdg.zip -j target/aarch64-unknown-linux-musl/release/ferium
 
 # Build for Musl Linux ARM64 without a GUI backend
 build-linux-arm64-nogui-musl:
     rm -f out/ferium-linux-musl-arm64-nogui.zip
     mkdir -p out
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc cargo build --target=aarch64-unknown-linux-musl --release --no-default-features
-    zip -r out/ferium-linux-musl-arm64-nogui.zip -j target/aarch64-unknown-linux-gnu/release/ferium
-    
+    CC_aarch64_unknown_linux_musl=clang AR_aarch64_unknown_linux_musl=llvm-ar CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld" cargo build --target=aarch64-unknown-linux-musl --release --no-default-features
+    zip -r out/ferium-linux-musl-arm64-nogui.zip -j target/aarch64-unknown-linux-musl/release/ferium
+
 # Run clippy lints
 lint:
     cargo clippy --   \


### PR DESCRIPTION
edit: includes PR: https://github.com/gorilla-devs/ferium/pull/194
closes https://github.com/gorilla-devs/ferium/issues/184
closes https://github.com/gorilla-devs/ferium/issues/134

With the rising numbers of ARM64 servers and desktop ARM64 users, it is nice to offer ARM64 linux builds.
This also includes @ImperatorStorm musl changes for x86_64 as well as my own GNU and Musl ARM64 changes