### PR TITLE
Switch to using musl libc for Linux builds to keep compatibility.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,17 @@ jobs:
         with:
           toolchain: stable
           target: x86_64-pc-windows-gnu
-
+      - name: Install Musl Rust target
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
       - name: Install Linux dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64
+          sudo apt-get install librust-gdk-dev gcc-mingw-w64-x86-64 musl musl-tools
 
       - name: Lint code
         run: just lint
@@ -65,9 +70,9 @@ jobs:
       - name: Build Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
-          just build-linux-nogui
-          just build-linux-gtk
-          just build-linux-xdg
+          just build-linux-gtk-musl
+          just build-linux-nogui-musl
+          just build-linux-xdg-musl
           just build-win-gnu
 
       - name: Upload build artefacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,13 @@ jobs:
         run: just lint
 
       - name: Run tests
+        if: matrix.os != 'ubuntu-latest'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          
+      - name: Run Musl tests
+        if: matrix.os == 'ubuntu-latest'
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-
+          args: --target=x86_64-unknown-linux-musl
+          
       - name: Build macOS
         if: matrix.os == 'macos-latest'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Download artefacts
+      - name: Download artifacts
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow_conclusion: success
@@ -51,10 +51,9 @@ jobs:
             Compiled binaries for Ferium version `${{ github.ref_name }}` ([changelog](https://github.com/gorilla-devs/ferium/blob/main/CHANGELOG.md#${{ env.MD_HEADER }}))
 
             The provided binaries are for:
-
-            - GNU Linux (x64 linux gnu) with GTK backend for GNOME
-            - GNU Linux (x64 linux gnu) without a GUI file dialogue and libraries
-            - GNU Linux (x64 linux gnu) with XDG backend for XDG Desktop Portal
+            - Linux (x64 linux) with GTK backend for GNOME
+            - Linux (x64 linux) without a GUI file dialogue and libraries
+            - Linux (x64 linux) with XDG Desktop Portal backend
             - macOS Apple Silicon (aarch64 darwin)
             - macOS Intel (x64 darwin)
             - GNU Windows, i.e. Cygwin/MinGW (x64 windows gnu)

--- a/justfile
+++ b/justfile
@@ -49,7 +49,28 @@ build-linux-nogui:
     mkdir -p out
     cargo build --target=x86_64-unknown-linux-gnu --release --no-default-features
     zip -r out/ferium-linux-gnu-nogui.zip -j target/x86_64-unknown-linux-gnu/release/ferium
-
+    
+# Build for Musl Linux with a GTK backend
+build-linux-gtk-musl:
+    rm -f out/ferium-linux-musl-gtk.zip
+    mkdir -p out
+    cargo build --target=x86_64-unknown-linux-musl --release
+    zip -r out/ferium-linux-musl-gtk.zip -j target/x86_64-unknown-linux-musl/release/ferium
+    
+# Build for Musl Linux with an XDG backend
+build-linux-xdg-musl:
+    rm -f out/ferium-linux-musl-xdg.zip
+    mkdir -p out
+    cargo build --target=x86_64-unknown-linux-musl --release --no-default-features --features xdg
+    zip -r out/ferium-linux-musl-xdg.zip -j target/x86_64-unknown-linux-musl/release/ferium
+    
+# Build for Musl Linux without a GUI backend
+build-linux-nogui-musl:
+    rm -f out/ferium-linux-musl-nogui.zip
+    mkdir -p out
+    cargo build --target=x86_64-unknown-linux-musl --release --no-default-features
+    zip -r out/ferium-linux-musl-nogui.zip -j target/x86_64-unknown-linux-musl/release/ferium
+    
 # Run clippy lints
 lint:
     cargo clippy --   \


### PR DESCRIPTION
Fixes #184, partially closes #191.