### PR TITLE
Enabled `ferium add` to take in multiple mod identifiers

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,7 +33,7 @@ pub enum SubCommands {
         /// The Modrinth project ID is specified at the bottom of the left sidebar under 'Technical information'. You can also use the project slug in the URL.
         /// The CurseForge mod ID is specified at the top of the right sidebar under 'About Project'.
         /// The GitHub identifier is the repository's full name, e.g. `gorilla-devs/ferium`.
-        identifier: String,
+        identifiers: Vec<String>,
         #[clap(long)]
         /// The game version will not be checked for this mod
         dont_check_game_version: bool,

--- a/src/download.rs
+++ b/src/download.rs
@@ -23,9 +23,12 @@ use tokio::{
 
 /// Check the given `directory`
 ///
-/// - If there are files there that are not in `to_download` or `to_install`, they will be moved to `directory`/.old
-/// - If a file in `to_download` or `to_install` is already there, it will be removed from the respective vector
-/// - If the file is a `.part` file or if the move failed, the file will be deleted
+/// - If there are files there that are not in `to_download` or `to_install`,
+///   they will be moved to `directory`/.old
+/// - If a file in `to_download` or `to_install` is already there, it will be
+///   removed from the respective vector
+/// - If the file is a `.part` file or if the move failed, the file will be
+///   deleted
 pub async fn clean(
     directory: &Path,
     to_download: &mut Vec<Downloadable>,
@@ -48,7 +51,7 @@ pub async fn clean(
         );
     }
     create_dir_all(directory.join(".old")).await?;
-    for file in read_dir(&directory)? {
+    for file in read_dir(directory)? {
         let file = file?;
         // If it's a file
         if file.file_type()?.is_file() {
@@ -67,7 +70,8 @@ pub async fn clean(
                 // Don't install it
                 to_install.swap_remove(index);
             // Or else, move the file to `directory`/.old
-            // If the file is a `.part` file or if the move failed, delete the file
+            // If the file is a `.part` file or if the move failed, delete the
+            // file
             } else if filename.ends_with("part")
                 || move_file(
                     file.path(),
@@ -93,7 +97,8 @@ pub fn read_overrides(directory: &Path) -> Result<Vec<(OsString, PathBuf)>> {
     Ok(to_install)
 }
 
-/// Download and install the files in `to_download` and `to_install` to `output_dir`
+/// Download and install the files in `to_download` and `to_install` to
+/// `output_dir`
 pub async fn download(
     output_dir: Arc<PathBuf>,
     to_download: Vec<Downloadable>,
@@ -167,7 +172,8 @@ pub async fn download(
     Ok(())
 }
 
-/// Find duplicates of the items in `slice` using a value obtained by the `key` closure
+/// Find duplicates of the items in `slice` using a value obtained by the `key`
+/// closure
 ///
 /// Returns the indices of duplicate items in reverse order for easy removal
 fn find_dupes_by_key<T, V, F>(slice: &mut [T], key: F) -> Vec<usize>
@@ -180,7 +186,7 @@ where
         return indices;
     }
     slice.sort_unstable_by_key(&key);
-    for i in 0..(slice.len() - 1) {
+    for i in 0 .. (slice.len() - 1) {
         if key(&slice[i]) == key(&slice[i + 1]) {
             indices.push(i);
         }

--- a/src/subcommands/add.rs
+++ b/src/subcommands/add.rs
@@ -2,8 +2,7 @@ use crate::{CROSS, THEME, TICK};
 use anyhow::{bail, Result};
 use colored::Colorize;
 use dialoguer::Confirm;
-use ferinth::structures::version_structs::DependencyType;
-use ferinth::Ferinth;
+use ferinth::{structures::version_structs::DependencyType, Ferinth};
 use furse::{structures::file_structs::FileRelationType, Furse};
 use itertools::Itertools;
 use libium::{
@@ -29,14 +28,17 @@ pub async fn github(
     .await?;
     println!("{} {}", *TICK, repo.name.bold());
     profile.mods.push(Mod {
-        name: repo.name.trim().into(),
-        identifier: ModIdentifier::GitHubRepository((repo.owner.expect("Could not get repository owner").login, repo.name)),
+        name:               repo.name.trim().into(),
+        identifier:         ModIdentifier::GitHubRepository((
+            repo.owner.expect("Could not get repository owner").login,
+            repo.name,
+        )),
         check_game_version: if should_check_game_version == Some(true) {
             None
         } else {
             should_check_game_version
         },
-        check_mod_loader: if should_check_mod_loader == Some(true) {
+        check_mod_loader:   if should_check_mod_loader == Some(true) {
             None
         } else {
             should_check_mod_loader
@@ -46,7 +48,7 @@ pub async fn github(
 }
 
 pub async fn modrinth(
-    modrinth: Arc<Ferinth>,
+    modrinth: &Arc<Ferinth>,
     project_id: &str,
     profile: &mut Profile,
     should_check_game_version: Option<bool>,
@@ -64,14 +66,14 @@ pub async fn modrinth(
     .await?;
     println!("{} {}", *TICK, project.title.bold());
     profile.mods.push(Mod {
-        name: project.title.trim().into(),
-        identifier: ModIdentifier::ModrinthProject(project.id),
+        name:               project.title.trim().into(),
+        identifier:         ModIdentifier::ModrinthProject(project.id),
         check_game_version: if should_check_game_version == Some(true) {
             None
         } else {
             should_check_game_version
         },
-        check_mod_loader: if should_check_mod_loader == Some(true) {
+        check_mod_loader:   if should_check_mod_loader == Some(true) {
             None
         } else {
             should_check_mod_loader
@@ -93,14 +95,14 @@ pub async fn modrinth(
                         println!("{} {}", *TICK, project.title.bold());
                         // If it's required, add it without asking
                         profile.mods.push(Mod {
-                            name: project.title.trim().into(),
-                            identifier: ModIdentifier::ModrinthProject(project.id),
+                            name:               project.title.trim().into(),
+                            identifier:         ModIdentifier::ModrinthProject(project.id),
                             check_game_version: if should_check_game_version == Some(true) {
                                 None
                             } else {
                                 should_check_game_version
                             },
-                            check_mod_loader: if should_check_mod_loader == Some(true) {
+                            check_mod_loader:   if should_check_mod_loader == Some(true) {
                                 None
                             } else {
                                 should_check_mod_loader
@@ -132,14 +134,14 @@ pub async fn modrinth(
                             .interact()?
                         {
                             profile.mods.push(Mod {
-                                name: project.title.trim().into(),
-                                identifier: ModIdentifier::ModrinthProject(project.id),
+                                name:               project.title.trim().into(),
+                                identifier:         ModIdentifier::ModrinthProject(project.id),
                                 check_game_version: if should_check_game_version == Some(true) {
                                     None
                                 } else {
                                     should_check_game_version
                                 },
-                                check_mod_loader: if should_check_mod_loader == Some(true) {
+                                check_mod_loader:   if should_check_mod_loader == Some(true) {
                                     None
                                 } else {
                                     should_check_mod_loader
@@ -178,7 +180,7 @@ pub async fn modrinth(
 }
 
 pub async fn curseforge(
-    curseforge: Arc<Furse>,
+    curseforge: &Arc<Furse>,
     project_id: i32,
     profile: &mut Profile,
     should_check_game_version: Option<bool>,
@@ -196,14 +198,14 @@ pub async fn curseforge(
     .await?;
     println!("{} {}", *TICK, project.name.bold());
     profile.mods.push(Mod {
-        name: project.name.trim().into(),
-        identifier: ModIdentifier::CurseForgeProject(project.id),
+        name:               project.name.trim().into(),
+        identifier:         ModIdentifier::CurseForgeProject(project.id),
         check_game_version: if should_check_game_version == Some(true) {
             None
         } else {
             should_check_game_version
         },
-        check_mod_loader: if should_check_mod_loader == Some(true) {
+        check_mod_loader:   if should_check_mod_loader == Some(true) {
             None
         } else {
             should_check_mod_loader
@@ -219,14 +221,14 @@ pub async fn curseforge(
                         println!("{} {}", *TICK, project.name.bold());
                         // If it's required, add it without asking
                         profile.mods.push(Mod {
-                            name: project.name.trim().into(),
-                            identifier: ModIdentifier::CurseForgeProject(project.id),
+                            name:               project.name.trim().into(),
+                            identifier:         ModIdentifier::CurseForgeProject(project.id),
                             check_game_version: if should_check_game_version == Some(true) {
                                 None
                             } else {
                                 should_check_game_version
                             },
-                            check_mod_loader: if should_check_mod_loader == Some(true) {
+                            check_mod_loader:   if should_check_mod_loader == Some(true) {
                                 None
                             } else {
                                 should_check_mod_loader
@@ -256,14 +258,14 @@ pub async fn curseforge(
                             .interact()?
                         {
                             profile.mods.push(Mod {
-                                name: project.name.trim().into(),
-                                identifier: ModIdentifier::CurseForgeProject(project.id),
+                                name:               project.name.trim().into(),
+                                identifier:         ModIdentifier::CurseForgeProject(project.id),
                                 check_game_version: if should_check_game_version == Some(true) {
                                     None
                                 } else {
                                     should_check_game_version
                                 },
-                                check_mod_loader: if should_check_mod_loader == Some(true) {
+                                check_mod_loader:   if should_check_mod_loader == Some(true) {
                                     None
                                 } else {
                                     should_check_mod_loader

--- a/src/subcommands/modpack/mod.rs
+++ b/src/subcommands/modpack/mod.rs
@@ -41,7 +41,7 @@ pub async fn check_output_directory(output_dir: &Path) -> Result<()> {
                 .with_prompt("Would like to create a backup?")
                 .interact()?
             {
-                let backup_dir = pick_folder(&*HOME, "Where should the backup be made?")
+                let backup_dir = pick_folder(&HOME, "Where should the backup be made?")
                     .await
                     .ok_or_else(|| anyhow!("Please pick an output directory"))?;
                 copy(check_dir, backup_dir, &CopyOptions::new())?;

--- a/src/subcommands/profile/mod.rs
+++ b/src/subcommands/profile/mod.rs
@@ -88,7 +88,7 @@ pub async fn check_output_directory(output_dir: &PathBuf) -> Result<()> {
             .with_prompt("Would like to create a backup?")
             .interact()?
         {
-            let backup_dir = pick_folder(&*HOME, "Where should the backup be made?")
+            let backup_dir = pick_folder(&HOME, "Where should the backup be made?")
                 .await
                 .expect("Please pick a backup directory");
             create_dir_all(&backup_dir).await?;

--- a/src/subcommands/remove.rs
+++ b/src/subcommands/remove.rs
@@ -3,7 +3,8 @@ use anyhow::{bail, Result};
 use dialoguer::MultiSelect;
 use libium::config::structs::Profile;
 
-/// Display a list of mods and repos in the profile to select from and remove selected ones
+/// Display a list of mods and repos in the profile to select from and remove
+/// selected ones
 pub fn remove(profile: &mut Profile, mod_names: Vec<String>) -> Result<()> {
     let names = profile
         .mods

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -190,6 +190,55 @@ fn already_added() {
 }
 
 #[test]
+fn add_multiple_modrinth() -> Result {
+    run_command(
+        vec!["add", "starlight", "sodium", "lithium"],
+        Some("empty_profile"),
+    )
+}
+
+#[test]
+fn add_multiple_curseforge() -> Result {
+    // Add Carpet Mod, Terralith, and Curseforge to the config
+    run_command(
+        vec!["add", "349239", "591388", "225608"],
+        Some("empty_profile"),
+    )
+}
+
+#[test]
+fn add_multiple_github() -> Result {
+    run_command(
+        vec!["add", "CaffeineMC/sodium-fabric", "gnembon/fabric-carpet"],
+        Some("empty_profile"),
+    )
+}
+
+#[test]
+fn add_mixed() -> Result { run_command(vec!["add", "starlight", "349239"], Some("empty_profile")) }
+
+#[test]
+fn already_added_multiple() {
+    assert!(run_command(
+        vec!["add", "StArLiGhT", "lithium"],
+        Some("one_profile_full")
+    )
+    .is_err());
+    assert!(run_command(vec!["add", "591388", "349239"], Some("one_profile_full")).is_err());
+    assert!(run_command(
+        vec![
+            "add",
+            "caffeinemc",
+            "Sodium-Fabric",
+            "gnembon",
+            "fabric-carpet"
+        ],
+        Some("one_profile_full")
+    )
+    .is_err());
+}
+
+#[test]
 fn list() -> Result { run_command(vec!["list"], Some("one_profile_full")) }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -190,14 +190,10 @@ fn already_added() {
 }
 
 #[test]
-fn list() -> Result {
-    run_command(vec!["list"], Some("one_profile_full"))
-}
+fn list() -> Result { run_command(vec!["list"], Some("one_profile_full")) }
 
 #[test]
-fn list_verbose() -> Result {
-    run_command(vec!["list", "--verbose"], Some("one_profile_full"))
-}
+fn list_verbose() -> Result { run_command(vec!["list", "--verbose"], Some("one_profile_full")) }
 
 #[test]
 fn list_markdown() -> Result {
@@ -208,9 +204,7 @@ fn list_markdown() -> Result {
 }
 
 #[test]
-fn profile_list() -> Result {
-    run_command(vec!["profile", "list"], Some("one_profile_full"))
-}
+fn profile_list() -> Result { run_command(vec!["profile", "list"], Some("one_profile_full")) }
 
 #[test]
 fn upgrade() -> Result {

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,7 +1,9 @@
 use std::process::Command;
 
-use std::fs::{copy, create_dir};
-use std::io::Result;
+use std::{
+    fs::{copy, create_dir},
+    io::Result,
+};
 
 pub fn run_command(args: Vec<&str>, config_file: Option<&str>) -> Result<()> {
     let mut args = args; // Borrow checker bug (I think)


### PR DESCRIPTION
This patch directly addresses #175. It allows you to add multiple mods at once using the `ferium add` command like so: `ferium add sodium lithium starlight`. I added some tests to test adding multiple mods at once.