### PR TITLE
Reduce max number of simultaneous connections

### DIFF
--- a/src/subcommands/upgrade.rs
+++ b/src/subcommands/upgrade.rs
@@ -35,7 +35,7 @@ pub async fn upgrade(
     let mut tasks = Vec::new();
 
     println!("{}\n", "Determining the Latest Compatible Versions".bold());
-    let semaphore = Arc::new(Semaphore::new(75));
+    let semaphore = Arc::new(Semaphore::new(40));
     progress_bar
         .force_lock()
         .enable_steady_tick(Duration::from_millis(100));


### PR DESCRIPTION
The Modrinth API breaks when there are more than 43 or more simultaneous connections on a single http2 stream, so limit the number of requests to 40 to be safe

Closes #224