### PR TITLE
Extend CLI

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 format_code_in_doc_comments = true
-enum_discrim_align_threshold = 20
-struct_field_align_threshold = 20
+# enum_discrim_align_threshold = 20
+# struct_field_align_threshold = 20
 condense_wildcard_suffixes = true
 match_block_trailing_comma = true
 normalize_doc_attributes = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,8 @@ pub enum SubCommands {
         /// Useful for creating modpack mod lists.
         /// Complements the verbose flag.
         markdown: bool,
+        #[clap(long, short)]
+        export: bool,
     },
     #[clap(arg_required_else_help = true)]
     /// Add, configure, delete, switch, list, or upgrade modpacks

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,7 +90,11 @@ pub enum SubCommands {
         mod_names: Vec<String>,
     },
     /// Download and install the latest version of the mods specified
-    Upgrade,
+    Upgrade {
+        #[clap(long, short)]
+        /// Don’t print compatible mods
+        less: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,8 @@ pub enum SubCommands {
         /// The Modrinth project ID is specified at the bottom of the left sidebar under 'Technical information'. You can also use the project slug in the URL.
         /// The CurseForge mod ID is specified at the top of the right sidebar under 'About Project'.
         /// The GitHub identifier is the repository's full name, e.g. `gorilla-devs/ferium`.
-        identifier: String,
+        identifiers: Vec<String>,
+
         #[clap(long)]
         /// The game version will not be checked for this mod
         dont_check_game_version: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,11 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
                 return Err(anyhow!(""));
             }
         },
-        SubCommands::List { verbose, markdown } => {
+        SubCommands::List {
+            verbose,
+            markdown,
+            export,
+        } => {
             let profile = get_active_profile(&mut config)?;
             check_empty_profile(profile)?;
             if verbose {
@@ -207,17 +211,27 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
                 }
             } else {
                 for mod_ in &profile.mods {
-                    println!("{:45} {}", mod_.name.bold(), match &mod_.identifier {
-                        ModIdentifier::CurseForgeProject(id) =>
-                            format!("{:10} {}", "CurseForge".red(), id.to_string().dimmed()),
-                        ModIdentifier::ModrinthProject(id) =>
-                            format!("{:10} {}", "Modrinth".green(), id.dimmed()),
-                        ModIdentifier::GitHubRepository(name) => format!(
-                            "{:10} {}",
-                            "GitHub".purple(),
-                            format!("{}/{}", name.0, name.1).dimmed()
-                        ),
-                    },);
+                    if export {
+                        match &mod_.identifier {
+                            ModIdentifier::CurseForgeProject(id) => println!("{}", id),
+                            ModIdentifier::ModrinthProject(id) => println!("{}", id),
+                            ModIdentifier::GitHubRepository(name) => {
+                                println!("{}/{}", name.0, name.1)
+                            },
+                        }
+                    } else {
+                        println!("{:45} {}", mod_.name.bold(), match &mod_.identifier {
+                            ModIdentifier::CurseForgeProject(id) =>
+                                format!("{:10} {}", "CurseForge".red(), id.to_string().dimmed()),
+                            ModIdentifier::ModrinthProject(id) =>
+                                format!("{:10} {}", "Modrinth".green(), id.dimmed()),
+                            ModIdentifier::GitHubRepository(name) => format!(
+                                "{:10} {}",
+                                "GitHub".purple(),
+                                format!("{}/{}", name.0, name.1).dimmed()
+                            ),
+                        },);
+                    }
                 }
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,11 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
                 {
                     Ok(_) => {},
                     Err(e) => {
-                        eprintln!("{}", e.to_string().red().bold());
+                        if e.to_string() == libium::add::Error::AlreadyAdded.to_string() {
+                            println!("{} Already added", *TICK);
+                        } else {
+                            eprintln!("{}", e.to_string().red().bold());
+                        }
                         error = true;
                     },
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,11 +356,11 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
             check_empty_profile(profile)?;
             subcommands::remove(profile, mod_names)?;
         },
-        SubCommands::Upgrade => {
+        SubCommands::Upgrade { less } => {
             check_internet().await?;
             let profile = get_active_profile(&mut config)?;
             check_empty_profile(profile)?;
-            subcommands::upgrade(modrinth, curseforge, github, profile).await?;
+            subcommands::upgrade(modrinth, curseforge, github, profile, less).await?;
         },
     };
 

--- a/src/subcommands/add.rs
+++ b/src/subcommands/add.rs
@@ -149,7 +149,7 @@ pub async fn modrinth(
             }
 
             if dependency.dependency_type == DependencyType::Required {
-                eprint!("Adding required dependency {}... ", id.dimmed());
+                eprint!("  ⮱ Adding required dependency {}... ", id.dimmed());
                 let project = modrinth.get_project(&id).await?;
                 match add::modrinth(modrinth, &project, profile, None, None).await {
                     Ok(_) => {
@@ -182,9 +182,9 @@ pub async fn modrinth(
                 && (dependencies == &Some(DependencyLevel::All) || dependencies.is_none())
             {
                 if dependencies == &Some(DependencyLevel::All) {
-                    eprint!("Adding optional dependency {}... ", id.dimmed());
+                    eprint!("  ⮱ Adding optional dependency {}... ", id.dimmed());
                 } else {
-                    eprint!("Checking optional dependency {}... ", id.dimmed());
+                    eprint!("  ⮱ Checking optional dependency {}... ", id.dimmed());
                 }
                 let project = modrinth.get_project(&id).await?;
                 match add::modrinth(modrinth, &project, profile, None, None).await {
@@ -196,7 +196,7 @@ pub async fn modrinth(
                         if dependencies == &Some(DependencyLevel::All)
                             || match Confirm::with_theme(&*THEME)
                                 .with_prompt(format!(
-                                    "Add optional dependency {} ({})?",
+                                    "  ⮱ Add optional dependency {} ({})?",
                                     project.title.bold(),
                                     format!("https://modrinth.com/mod/{}", project.slug)
                                         .blue()
@@ -241,7 +241,7 @@ pub async fn modrinth(
 
     if !project.donation_urls.is_empty() {
         println!(
-            "Consider supporting the mod creator on {}",
+            "  ⮱ Consider supporting the mod creator on {}",
             project
                 .donation_urls
                 .iter()
@@ -293,7 +293,10 @@ pub async fn curseforge(
         for dependency in &latest_file.dependencies {
             let id = dependency.mod_id;
             if dependency.relation_type == FileRelationType::RequiredDependency {
-                eprint!("Adding required dependency {}... ", id.to_string().dimmed());
+                eprint!(
+                    "  ⮱ Adding required dependency {}... ",
+                    id.to_string().dimmed()
+                );
                 let project = curseforge.get_mod(id).await?;
                 match add::curseforge(curseforge, &project, profile, None, None).await {
                     Ok(_) => {
@@ -326,10 +329,13 @@ pub async fn curseforge(
                 && (dependencies == &Some(DependencyLevel::All) || dependencies.is_none())
             {
                 if dependencies == &Some(DependencyLevel::All) {
-                    eprint!("Adding optional dependency {}... ", id.to_string().dimmed());
+                    eprint!(
+                        "  ⮱ Adding optional dependency {}... ",
+                        id.to_string().dimmed()
+                    );
                 } else {
                     eprint!(
-                        "Checking optional dependency {}... ",
+                        "  ⮱ Checking optional dependency {}... ",
                         id.to_string().dimmed()
                     );
                 }
@@ -343,7 +349,7 @@ pub async fn curseforge(
                         if dependencies == &Some(DependencyLevel::All)
                             || Confirm::with_theme(&*THEME)
                                 .with_prompt(format!(
-                                    "Add optional dependency {} ({})?",
+                                    "  ⮱ Add optional dependency {} ({})?",
                                     project.name.bold(),
                                     project.links.website_url.to_string().blue().underline()
                                 ))

--- a/src/subcommands/upgrade.rs
+++ b/src/subcommands/upgrade.rs
@@ -28,6 +28,7 @@ pub async fn upgrade(
     curseforge: Furse,
     github: Octocrab,
     profile: &Profile,
+    less: bool,
 ) -> Result<()> {
     let profile = Arc::new(profile.clone());
     let to_download = Arc::new(Mutex::new(Vec::new()));
@@ -41,7 +42,7 @@ pub async fn upgrade(
     let modrinth = Arc::new(modrinth);
     let github = Arc::new(github);
 
-    println!("{}\n", "Determining the Latest Compatible Versions".bold());
+    println!("{}", "Determining the Latest Compatible Versions".bold());
     let semaphore = Arc::new(Semaphore::new(75));
     progress_bar
         .force_lock()
@@ -71,17 +72,19 @@ pub async fn upgrade(
             let progress_bar = progress_bar.force_lock();
             match result {
                 Ok((downloadable, backwards_compat)) => {
-                    progress_bar.println(format!(
-                        "{} {:43} {}",
-                        if backwards_compat {
-                            backwards_compat_msg.store(true, Ordering::Relaxed);
-                            YELLOW_TICK.clone()
-                        } else {
-                            TICK.clone()
-                        },
-                        mod_.name,
-                        downloadable.filename().dimmed()
-                    ));
+                    if !less {
+                        progress_bar.println(format!(
+                            "{} {:43} {}",
+                            if backwards_compat {
+                                backwards_compat_msg.store(true, Ordering::Relaxed);
+                                YELLOW_TICK.clone()
+                            } else {
+                                TICK.clone()
+                            },
+                            mod_.name,
+                            downloadable.filename().dimmed()
+                        ));
+                    }
                     {
                         let mut to_download = to_download.force_lock();
                         to_download.push(downloadable);


### PR DESCRIPTION
 - [x] close #285 by commenting out the threshold
 - [x] `ferium add` should accept multiple mods (#175): 
     - The command still exits with a non-0 exit code when failing to add a mod, but still adds the other mods before.
     - To differentiate between mods and dependencies I indented the deps
     - When adding an already existing mod the message should be green
     - to comply with the integration test, it still exits non-0
     - the overwrite flags are applied to all mods as I think that is the expected behavior.
 - [x] `ferium list -e/--export` prints mod ids without formatting to be imported later
   - you can do `ferium list -e > modlist`, then switch profile/pc and then do `ferium add $(cat modlist)` (on linux)
   - [ ] add doc comment
 - [x] `ferium upgrade -l/--less` hides, eg. doesn’t print all compatible mods, only showing those that actually get updated. (I have `ferium upgrade -l` in my upgrade script)
 - [ ] add search functionality like paru
 - [ ] easily add popular mods (like on the [Modrinth start page](https://modrinth.com/mods))
   - maybe `ferium search --popular`
 - [ ] add `ferium install` to add + download only that mod (#163)
   - should accept multiple mods
   - when already added, should download them
 - [ ] fix `ferium remove`: Doesn’t remove the mod properly. `ferium remove <mod>` works.
 - [ ] remove mods by id (#266)
 - [ ] MAYBE: add `--dry-run` (#162) OR add y/n question + `-f/--force` (#49)