### PR TITLE
add `-e/--export` option to `ferium list` to print ids without formatting

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,6 +71,9 @@ pub enum SubCommands {
         /// Useful for creating modpack mod lists.
         /// Complements the verbose flag.
         markdown: bool,
+        #[clap(long, short)]
+        /// Output only mod id’s.
+        export: bool,
     },
     #[clap(arg_required_else_help = true)]
     /// Add, configure, delete, switch, list, or upgrade modpacks

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,11 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
                 );
             }
         }
-        SubCommands::List { verbose, markdown } => {
+        SubCommands::List {
+            verbose,
+            markdown,
+            export,
+        } => {
             let profile = get_active_profile(&mut config)?;
             check_empty_profile(profile)?;
             if verbose {
@@ -248,21 +252,31 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
                 }
             } else {
                 for mod_ in &profile.mods {
-                    println!(
-                        "{:45} {}",
-                        mod_.name.bold(),
+                    if export {
                         match &mod_.identifier {
-                            ModIdentifier::CurseForgeProject(id) =>
-                                format!("{:10} {}", "CurseForge".red(), id.to_string().dimmed()),
-                            ModIdentifier::ModrinthProject(id) =>
-                                format!("{:10} {}", "Modrinth".green(), id.dimmed()),
-                            ModIdentifier::GitHubRepository(name) => format!(
-                                "{:10} {}",
-                                "GitHub".purple(),
-                                format!("{}/{}", name.0, name.1).dimmed()
-                            ),
-                        },
-                    );
+                            ModIdentifier::CurseForgeProject(id) => println!("{}", id),
+                            ModIdentifier::ModrinthProject(id) => println!("{}", id),
+                            ModIdentifier::GitHubRepository(name) => {
+                                println!("{}/{}", name.0, name.1)
+                            }
+                        }
+                    } else {
+                        println!(
+                            "{:45} {}",
+                            mod_.name.bold(),
+                            match &mod_.identifier {
+                                ModIdentifier::CurseForgeProject(id) =>
+                                    format!("{:10} {}", "CurseForge".red(), id.to_string().dimmed()),
+                                ModIdentifier::ModrinthProject(id) =>
+                                    format!("{:10} {}", "Modrinth".green(), id.dimmed()),
+                                ModIdentifier::GitHubRepository(name) => format!(
+                                    "{:10} {}",
+                                    "GitHub".purple(),
+                                    format!("{}/{}", name.0, name.1).dimmed()
+                                ),
+                            },
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is useful to quickly send a set of mods to someone who can just install them easily.