### PR TITLE
better list formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,6 @@ You can manually run cargo commands, but I recommend [`just`](https://just.syste
 To build the project and install it to your Cargo binary directory, clone the project and run `just install`.
 If you want to install it for testing purposes run `just` (alias to `just install-dev`), which builds in debug mode.
 
-You can run integration tests using `cargo test`, linters using `cargo clippy`, and delete all build and test artefacts using `just clean`.
+You can run integration tests using `cargo test`, linters using `cargo clippy`, and delete all build and test artifacts using `just clean`.
 
 If you would like to see instructions for building for specific targets (e.g. Linux ARM), have a look at the [workflow file](.github/workflows/build.yml). If you're still confused, [create a discussion](https://github.com/gorilla-devs/ferium/discussions/new?category=q-a) and I will help you out.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,10 +66,9 @@ pub enum SubCommands {
         /// Show additional information about the mod
         verbose: bool,
         #[clap(long, short)]
-        /// Output information in markdown format and alphabetical order
-        ///
+        /// Like verbose, but outputs information in markdown format and ordered alphabetically
+        /// 
         /// Useful for creating modpack mod lists.
-        /// Complements the verbose flag.
         markdown: bool,
     },
     #[clap(arg_required_else_help = true)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
         SubCommands::List { verbose, markdown } => {
             let profile = get_active_profile(&mut config)?;
             check_empty_profile(profile)?;
-            if verbose {
+            if verbose || markdown {
                 check_internet().await?;
                 let mut tasks = JoinSet::new();
                 let mut mr_ids = Vec::<&str>::new();
@@ -249,19 +249,19 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
             } else {
                 for mod_ in &profile.mods {
                     println!(
-                        "{:45} {}",
-                        mod_.name.bold(),
+                        "{} {}",
                         match &mod_.identifier {
                             ModIdentifier::CurseForgeProject(id) =>
-                                format!("{:10} {}", "CurseForge".red(), id.to_string().dimmed()),
+                                format!("{:10} {:8}", "CurseForge".red(), id.to_string().dimmed()),
                             ModIdentifier::ModrinthProject(id) =>
-                                format!("{:10} {}", "Modrinth".green(), id.dimmed()),
+                                format!("{:10} {:8}", "Modrinth".green(), id.dimmed()),
                             ModIdentifier::GitHubRepository(name) => format!(
-                                "{:10} {}",
+                                "{:10} {:24}",
                                 "GitHub".purple(),
                                 format!("{}/{}", name.0, name.1).dimmed()
                             ),
                         },
+                        mod_.name.bold(),
                     );
                 }
             }


### PR DESCRIPTION
- updated `list` subcommand's output format to align IDs and make it visually easier to match ID to mod title
- made `--markdown` separate from `--verbose` flag
- fix README typo

Before this comit leading `ferium list` output was difficult because:
- mod's tittle had 45 character long margin which made it difficult to trace mod ID to the mod title visually if the title was short
- emojis in mod title made mod ID misaligned, because rust's format's pad can't properly calculate a width of emoji (2 byte unicode can be 1 character wide on terminal). Changing the order of arguments was a easier fix than adding a separate crate to properly calculate unicode width.
- `--markdown` flag could be used without `--verbose` but didn't do anything
- getting mod IDs with was difficult without `awk` or advanced `sed`. Now it's just `cut -d "" -f -1`

Before (look at kiwi):
![image](https://github.com/gorilla-devs/ferium/assets/5300963/400ad653-85f5-4177-af9c-aecfd8eb219a)

After:
![Screenshot from 2023-05-26 21-05-40](https://github.com/gorilla-devs/ferium/assets/5300963/395ff055-5ccf-474a-8119-dece4692027b)
