### PR TITLE
CLI tweaks resolving #250

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,6 @@ You can manually run cargo commands, but I recommend [`just`](https://just.syste
 To build the project and install it to your Cargo binary directory, clone the project and run `just install`.
 If you want to install it for testing purposes run `just` (alias to `just install-dev`), which builds in debug mode.
 
-You can run integration tests using `cargo test`, linters using `cargo clippy`, and delete all build and test artefacts using `just clean`.
+You can run integration tests using `cargo test`, linters using `cargo clippy`, and delete all build and test artifacts using `just clean`.
 
 If you would like to see instructions for building for specific targets (e.g. Linux ARM), have a look at the [workflow file](.github/workflows/build.yml). If you're still confused, [create a discussion](https://github.com/gorilla-devs/ferium/discussions/new?category=q-a) and I will help you out.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -143,6 +143,8 @@ pub enum ProfileSubCommands {
         /// The name of the profile to delete
         profile_name: Option<String>,
     },
+    /// Show active profile's information
+    Info,
     /// List all the profiles with their data
     List,
     /// Switch between different profiles.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,10 +66,9 @@ pub enum SubCommands {
         /// Show additional information about the mod
         verbose: bool,
         #[clap(long, short)]
-        /// Output information in markdown format and alphabetical order
-        ///
+        /// Like verbose, but outputs information in markdown format and ordered alphabetically
+        /// 
         /// Useful for creating modpack mod lists.
-        /// Complements the verbose flag.
         markdown: bool,
     },
     #[clap(arg_required_else_help = true)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -193,6 +193,8 @@ pub enum ModpackSubCommands {
         /// The name of the modpack to delete
         modpack_name: Option<String>,
     },
+    /// Show active profile's information
+    Info,
     /// List all the modpacks
     List,
     /// Switch between different modpacks.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,6 +60,7 @@ pub enum SubCommands {
         /// The shell to generate auto completions for
         shell: Shell,
     },
+    #[clap(alias = "mods")]
     /// List all the mods in the profile, and with some their metadata if verbose
     List {
         #[clap(long, short)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -382,7 +382,7 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
                 }
                 println!(
                     "{}",
-                    subcommands::profile::info(get_active_profile(&mut config)?, true)
+                    subcommands::profile::info(get_active_profile(&mut config)?, false)
                 );
             }
             ProfileSubCommands::List => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn main() -> ExitCode {
     let runtime = builder.build().expect("Could not initialise Tokio runtime");
     if let Err(err) = runtime.block_on(actual_main(cli)) {
         eprintln!("{}", err.to_string().red().bold());
-        hint_on_error(err);
+        hint_on_error(&err);
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS
@@ -491,15 +491,12 @@ fn get_oneline_mod_info(mod_: &Mod) -> String {
     )
 }
 
-fn hint_on_error(err: anyhow::Error) {
-    match err.downcast_ref::<libium::add::Error>() {
-        Some(libium::add::Error::Incompatible) => {
-            eprintln!(
-                "{}",
-                "Hint: Use --dont-check-game-version and/or --dont-check-mod-loader to override checks. \
-                 Use `ferium add --help` to learn more.".dimmed()
-            );
-        }
-        _ => {}
+fn hint_on_error(err: &anyhow::Error) {
+    if let Some(libium::add::Error::Incompatible) = err.downcast_ref::<libium::add::Error>() {
+        eprintln!(
+            "{}",
+            "Hint: Use --dont-check-... flags to override checks and force installation. \
+            Use `ferium add --help` to learn more.".dimmed()
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -368,6 +368,12 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
             ProfileSubCommands::Delete { profile_name } => {
                 subcommands::profile::delete(&mut config, profile_name)?;
             }
+            ProfileSubCommands::Info => {
+                if config.profiles.is_empty() {
+                    bail!("There are no profiles configured, create a profile using `ferium profile create`")
+                }
+                println!("{}", subcommands::profile::info(get_active_profile(&mut config)?, true));
+            }
             ProfileSubCommands::List => {
                 if config.profiles.is_empty() {
                     bail!("There are no profiles configured, create a profile using `ferium profile create`")

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,14 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
         }
         SubCommands::List { verbose, markdown } => {
             let profile = get_active_profile(&mut config)?;
+            println!(
+                "{}\n",
+                if markdown {
+                    subcommands::profile::info_md(profile)
+                } else {
+                    subcommands::profile::info(profile, false)
+                }
+            );
             check_empty_profile(profile)?;
             if verbose || markdown {
                 check_internet().await?;
@@ -372,7 +380,10 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
                 if config.profiles.is_empty() {
                     bail!("There are no profiles configured, create a profile using `ferium profile create`")
                 }
-                println!("{}", subcommands::profile::info(get_active_profile(&mut config)?, true));
+                println!(
+                    "{}",
+                    subcommands::profile::info(get_active_profile(&mut config)?, true)
+                );
             }
             ProfileSubCommands::List => {
                 if config.profiles.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,7 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
         SubCommands::List { verbose, markdown } => {
             let profile = get_active_profile(&mut config)?;
             check_empty_profile(profile)?;
-            if verbose {
+            if verbose || markdown {
                 check_internet().await?;
                 let github = github.build()?;
                 let mut tasks = JoinSet::new();
@@ -245,19 +245,19 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
             } else {
                 for mod_ in &profile.mods {
                     println!(
-                        "{:45} {}",
-                        mod_.name.bold(),
+                        "{} {}",
                         match &mod_.identifier {
                             ModIdentifier::CurseForgeProject(id) =>
-                                format!("{:10} {}", "CurseForge".red(), id.to_string().dimmed()),
+                                format!("{:10} {:8}", "CurseForge".red(), id.to_string().dimmed()),
                             ModIdentifier::ModrinthProject(id) =>
-                                format!("{:10} {}", "Modrinth".green(), id.dimmed()),
+                                format!("{:10} {:8}", "Modrinth".green(), id.dimmed()),
                             ModIdentifier::GitHubRepository(name) => format!(
-                                "{:10} {}",
+                                "{:10} {:24}",
                                 "GitHub".purple(),
                                 format!("{}/{}", name.0, name.1).dimmed()
                             ),
                         },
+                        mod_.name.bold(),
                     );
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -377,18 +377,13 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
                 subcommands::profile::delete(&mut config, profile_name)?;
             }
             ProfileSubCommands::Info => {
-                if config.profiles.is_empty() {
-                    bail!("There are no profiles configured, create a profile using `ferium profile create`")
-                }
                 println!(
                     "{}",
                     subcommands::profile::info(get_active_profile(&mut config)?, false)
                 );
             }
             ProfileSubCommands::List => {
-                if config.profiles.is_empty() {
-                    bail!("There are no profiles configured, create a profile using `ferium profile create`")
-                }
+                check_any_profile(&config)?;
                 subcommands::profile::list(&config);
             }
             ProfileSubCommands::Switch { profile_name } => {
@@ -421,10 +416,8 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
 
 /// Get the active profile with error handling
 fn get_active_profile(config: &mut Config) -> Result<&mut Profile> {
+    check_any_profile(config)?;
     match config.profiles.len() {
-        0 => {
-            bail!("There are no profiles configured, add a profile using `ferium profile create`")
-        }
         1 => config.active_profile = 0,
         n if n <= config.active_profile => {
             println!(
@@ -463,6 +456,14 @@ fn get_active_modpack(config: &mut Config) -> Result<&mut Modpack> {
 fn check_empty_profile(profile: &Profile) -> Result<()> {
     if profile.mods.is_empty() {
         bail!("Your currently selected profile is empty! Run `ferium help` to see how to add mods");
+    }
+    Ok(())
+}
+
+/// Check if there are any profiles configured
+fn check_any_profile(config: &Config) -> Result<()> {
+    if config.profiles.is_empty() {
+        bail!("There are no profiles configured, add a profile using `ferium profile create`")
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ use furse::Furse;
 use indicatif::ProgressStyle;
 use libium::config::{
     self,
-    structs::{Config, ModIdentifier, Modpack, Profile},
+    structs::{Config, Mod, ModIdentifier, Modpack, Profile},
 };
 use octocrab::OctocrabBuilder;
 use once_cell::sync::Lazy;
@@ -252,21 +252,7 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
                 }
             } else {
                 for mod_ in &profile.mods {
-                    println!(
-                        "{} {}",
-                        match &mod_.identifier {
-                            ModIdentifier::CurseForgeProject(id) =>
-                                format!("{:10} {:8}", "CurseForge".red(), id.to_string().dimmed()),
-                            ModIdentifier::ModrinthProject(id) =>
-                                format!("{:10} {:8}", "Modrinth".green(), id.dimmed()),
-                            ModIdentifier::GitHubRepository(name) => format!(
-                                "{:10} {:24}",
-                                "GitHub".purple(),
-                                format!("{}/{}", name.0, name.1).dimmed()
-                            ),
-                        },
-                        mod_.name.bold(),
-                    );
+                    println!("{}", get_oneline_mod_info(mod_));
                 }
             }
         }
@@ -484,4 +470,22 @@ async fn check_internet() -> Result<()> {
     client.get("https://api.github.com/").send().await?;
 
     Ok(())
+}
+
+fn get_oneline_mod_info(mod_: &Mod) -> String {
+    format!(
+        "{} {}",
+        match &mod_.identifier {
+            ModIdentifier::CurseForgeProject(id) =>
+                format!("{:10} {:8}", "CurseForge".red(), id.to_string().dimmed()),
+            ModIdentifier::ModrinthProject(id) =>
+                format!("{:10} {:8}", "Modrinth".green(), id.dimmed()),
+            ModIdentifier::GitHubRepository(name) => format!(
+                "{:10} {:24}",
+                "GitHub".purple(),
+                format!("{}/{}", name.0, name.1).dimmed()
+            ),
+        },
+        mod_.name.bold(),
+    )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,6 +304,12 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
             ModpackSubCommands::Delete { modpack_name } => {
                 subcommands::modpack::delete(&mut config, modpack_name)?;
             }
+            ModpackSubCommands::Info => {
+                println!(
+                    "{}",
+                    subcommands::modpack::info(get_active_modpack(&mut config)?, false)
+                );
+            }
             ModpackSubCommands::List => {
                 if config.modpacks.is_empty() {
                     bail!("There are no modpacks configured, add a modpack using `ferium modpack add`")

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,9 +178,9 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
             println!(
                 "{}\n",
                 if markdown {
-                    subcommands::profile::info_md(profile)
+                    subcommands::profile::info::profile_md(profile)
                 } else {
-                    subcommands::profile::info(profile, false)
+                    subcommands::profile::info::profile(profile, false)
                 }
             );
             check_empty_profile(profile)?;
@@ -365,7 +365,7 @@ async fn actual_main(cli_app: Ferium) -> Result<()> {
             ProfileSubCommands::Info => {
                 println!(
                     "{}",
-                    subcommands::profile::info(get_active_profile(&mut config)?, false)
+                    subcommands::profile::info::profile(get_active_profile(&mut config)?, false)
                 );
             }
             ProfileSubCommands::List => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,7 @@ fn main() -> ExitCode {
     let runtime = builder.build().expect("Could not initialise Tokio runtime");
     if let Err(err) = runtime.block_on(actual_main(cli)) {
         eprintln!("{}", err.to_string().red().bold());
+        hint_on_error(err);
         ExitCode::FAILURE
     } else {
         ExitCode::SUCCESS
@@ -488,4 +489,17 @@ fn get_oneline_mod_info(mod_: &Mod) -> String {
         },
         mod_.name.bold(),
     )
+}
+
+fn hint_on_error(err: anyhow::Error) {
+    match err.downcast_ref::<libium::add::Error>() {
+        Some(libium::add::Error::Incompatible) => {
+            eprintln!(
+                "{}",
+                "Hint: Use --dont-check-game-version and/or --dont-check-mod-loader to override checks. \
+                 Use `ferium add --help` to learn more.".dimmed()
+            );
+        }
+        _ => {}
+    }
 }

--- a/src/subcommands/modpack/info.rs
+++ b/src/subcommands/modpack/info.rs
@@ -1,0 +1,28 @@
+use colored::Colorize;
+use libium::config::structs::{Modpack, ModpackIdentifier};
+
+pub fn info(modpack: &Modpack, show_active_indicator: bool) -> String {
+    format!(
+        "\
+{}
+  Output directory:  {}
+  Identifier:        {}
+  Install Overrides: {}",
+  if show_active_indicator {
+      format!("{} (active)", modpack.name)
+                .bright_yellow()
+                .bold()
+                .underline()
+        } else {
+            modpack.name.bold()
+        },
+        match &modpack.identifier {
+            ModpackIdentifier::CurseForgeModpack(id) =>
+                format!("{:10} {}", "CurseForge".red(), id.to_string().dimmed()),
+            ModpackIdentifier::ModrinthModpack(id) =>
+                format!("{:10} {}", "Modrinth".green(), id.dimmed()),
+        },
+        modpack.output_dir.display().to_string().blue().underline(),
+        modpack.install_overrides,
+    )
+}

--- a/src/subcommands/modpack/info.rs
+++ b/src/subcommands/modpack/info.rs
@@ -16,13 +16,13 @@ pub fn info(modpack: &Modpack, show_active_indicator: bool) -> String {
         } else {
             modpack.name.bold()
         },
+        modpack.output_dir.display().to_string().blue().underline(),
         match &modpack.identifier {
             ModpackIdentifier::CurseForgeModpack(id) =>
                 format!("{:10} {}", "CurseForge".red(), id.to_string().dimmed()),
             ModpackIdentifier::ModrinthModpack(id) =>
                 format!("{:10} {}", "Modrinth".green(), id.dimmed()),
         },
-        modpack.output_dir.display().to_string().blue().underline(),
         modpack.install_overrides,
     )
 }

--- a/src/subcommands/modpack/list.rs
+++ b/src/subcommands/modpack/list.rs
@@ -1,23 +1,16 @@
-use colored::Colorize;
-use libium::config::structs::{Config, ModpackIdentifier};
+use itertools::Itertools;
+use libium::config::structs::Config;
+use crate::subcommands::modpack::info;
+
 
 pub fn list(config: &Config) {
-    for (i, modpack) in config.modpacks.iter().enumerate() {
-        println!(
-            "{}{}
-        \r  Output directory:  {}
-        \r  Identifier:        {}
-        \r  Install Overrides: {}\n",
-            modpack.name.bold(),
-            if i == config.active_modpack { " *" } else { "" },
-            modpack.output_dir.display().to_string().blue().underline(),
-            match &modpack.identifier {
-                ModpackIdentifier::CurseForgeModpack(id) =>
-                    format!("{:10} {}", "CurseForge".red(), id.to_string().dimmed()),
-                ModpackIdentifier::ModrinthModpack(id) =>
-                    format!("{:10} {}", "Modrinth".green(), id.dimmed()),
-            },
-            modpack.install_overrides
-        );
-    }
+    println!(
+        "{}",
+        config
+            .modpacks
+            .iter()
+            .enumerate()
+            .map(|(i, profile)| info::info(profile, i == config.active_profile))
+            .join("\n\n")
+    );
 }

--- a/src/subcommands/modpack/mod.rs
+++ b/src/subcommands/modpack/mod.rs
@@ -1,11 +1,13 @@
 pub mod add;
 mod configure;
 mod delete;
+mod info;
 mod list;
 mod switch;
 mod upgrade;
 pub use configure::configure;
 pub use delete::delete;
+pub use info::info;
 pub use list::list;
 pub use switch::switch;
 pub use upgrade::upgrade;

--- a/src/subcommands/profile/info.rs
+++ b/src/subcommands/profile/info.rs
@@ -4,16 +4,15 @@ use libium::config::structs::Profile;
 pub fn info(profile: &Profile, show_active_indicator: bool) -> String {
     return format!(
         "\
-{}{}
+{}
   Output directory:  {}
   Minecraft Version: {}
   Mod Loader:        {}
   Mods:              {}",
-        profile.name.bold(),
         if show_active_indicator {
-            " (active)".green().bold()
+            format!("{} (active)", profile.name).bright_yellow().bold().underline()
         } else {
-            "".normal()
+            profile.name.bold()
         },
         profile.output_dir.display().to_string().blue().underline(),
         profile.game_version.green(),

--- a/src/subcommands/profile/info.rs
+++ b/src/subcommands/profile/info.rs
@@ -3,16 +3,38 @@ use libium::config::structs::Profile;
 
 pub fn info(profile: &Profile, show_active_indicator: bool) -> String {
     return format!(
-        "{}{}
-        \r  Output directory:  {}
-        \r  Minecraft Version: {}
-        \r  Mod Loader:        {}
-        \r  Mods:              {}",
+        "\
+{}{}
+  Output directory:  {}
+  Minecraft Version: {}
+  Mod Loader:        {}
+  Mods:              {}",
         profile.name.bold(),
-        if show_active_indicator { " (active)".green().bold() } else { "".normal() },
+        if show_active_indicator {
+            " (active)".green().bold()
+        } else {
+            "".normal()
+        },
         profile.output_dir.display().to_string().blue().underline(),
         profile.game_version.green(),
         format!("{:?}", profile.mod_loader).purple(),
         profile.mods.len().to_string().yellow(),
+    );
+}
+
+pub fn info_md(profile: &Profile) -> String {
+    return format!(
+        "\
+# {}
+
+|                   |                 |
+|-------------------|:----------------|
+| Minecraft Version | _{}_            |
+| Mod Loader        | {}              |
+| Mods              | {}              |",
+        profile.name,
+        profile.game_version,
+        format!("{:?}", profile.mod_loader),
+        profile.mods.len().to_string(),
     );
 }

--- a/src/subcommands/profile/info.rs
+++ b/src/subcommands/profile/info.rs
@@ -1,8 +1,8 @@
 use colored::Colorize;
 use libium::config::structs::Profile;
 
-pub fn info(profile: &Profile, show_active_indicator: bool) -> String {
-    return format!(
+pub fn profile(profile: &Profile, show_active_indicator: bool) -> String {
+    format!(
         "\
 {}
   Output directory:  {}
@@ -10,7 +10,10 @@ pub fn info(profile: &Profile, show_active_indicator: bool) -> String {
   Mod Loader:        {}
   Mods:              {}",
         if show_active_indicator {
-            format!("{} (active)", profile.name).bright_yellow().bold().underline()
+            format!("{} (active)", profile.name)
+                .bright_yellow()
+                .bold()
+                .underline()
         } else {
             profile.name.bold()
         },
@@ -18,22 +21,22 @@ pub fn info(profile: &Profile, show_active_indicator: bool) -> String {
         profile.game_version.green(),
         format!("{:?}", profile.mod_loader).purple(),
         profile.mods.len().to_string().yellow(),
-    );
+    )
 }
 
-pub fn info_md(profile: &Profile) -> String {
-    return format!(
+pub fn profile_md(profile: &Profile) -> String {
+    format!(
         "\
 # {}
 
 |                   |                 |
 |-------------------|:----------------|
 | Minecraft Version | _{}_            |
-| Mod Loader        | {}              |
+| Mod Loader        | {:?}            |
 | Mods              | {}              |",
         profile.name,
         profile.game_version,
-        format!("{:?}", profile.mod_loader),
-        profile.mods.len().to_string(),
-    );
+        profile.mod_loader,
+        profile.mods.len(),
+    )
 }

--- a/src/subcommands/profile/info.rs
+++ b/src/subcommands/profile/info.rs
@@ -1,0 +1,18 @@
+use colored::Colorize;
+use libium::config::structs::Profile;
+
+pub fn info(profile: &Profile, show_active_indicator: bool) -> String {
+    return format!(
+        "{}{}
+        \r  Output directory:  {}
+        \r  Minecraft Version: {}
+        \r  Mod Loader:        {}
+        \r  Mods:              {}",
+        profile.name.bold(),
+        if show_active_indicator { " (active)".green().bold() } else { "".normal() },
+        profile.output_dir.display().to_string().blue().underline(),
+        profile.game_version.green(),
+        format!("{:?}", profile.mod_loader).purple(),
+        profile.mods.len().to_string().yellow(),
+    );
+}

--- a/src/subcommands/profile/list.rs
+++ b/src/subcommands/profile/list.rs
@@ -10,7 +10,7 @@ pub fn list(config: &Config) {
             .profiles
             .iter()
             .enumerate()
-            .map(|(i, profile)| info(profile, i == config.active_profile))
+            .map(|(i, profile)| info::profile(profile, i == config.active_profile))
             .join("\n\n")
     );
 }

--- a/src/subcommands/profile/list.rs
+++ b/src/subcommands/profile/list.rs
@@ -1,20 +1,16 @@
-use colored::Colorize;
+use itertools::Itertools;
 use libium::config::structs::Config;
 
+use crate::subcommands::profile::info;
+
 pub fn list(config: &Config) {
-    for (i, profile) in config.profiles.iter().enumerate() {
-        println!(
-            "{}{}
-        \r  Output directory:   {}
-        \r  Minecraft Version:  {}
-        \r  Mod Loader:         {}
-        \r  Mods:               {}\n",
-            profile.name.bold(),
-            if i == config.active_profile { " *" } else { "" },
-            profile.output_dir.display().to_string().blue().underline(),
-            profile.game_version.green(),
-            format!("{:?}", profile.mod_loader).purple(),
-            profile.mods.len().to_string().yellow(),
-        );
-    }
+    println!(
+        "{}",
+        config
+            .profiles
+            .iter()
+            .enumerate()
+            .map(|(i, profile)| info(profile, i == config.active_profile))
+            .join("\n\n")
+    );
 }

--- a/src/subcommands/profile/mod.rs
+++ b/src/subcommands/profile/mod.rs
@@ -7,7 +7,7 @@ mod switch;
 pub use configure::configure;
 pub use create::create;
 pub use delete::delete;
-pub use info::info;
+pub use info::{info, info_md};
 pub use list::list;
 pub use switch::switch;
 

--- a/src/subcommands/profile/mod.rs
+++ b/src/subcommands/profile/mod.rs
@@ -1,11 +1,13 @@
 mod configure;
 mod create;
 mod delete;
+mod info;
 mod list;
 mod switch;
 pub use configure::configure;
 pub use create::create;
 pub use delete::delete;
+pub use info::info;
 pub use list::list;
 pub use switch::switch;
 

--- a/src/subcommands/profile/mod.rs
+++ b/src/subcommands/profile/mod.rs
@@ -1,13 +1,12 @@
 mod configure;
 mod create;
 mod delete;
-mod info;
+pub mod info;
 mod list;
 mod switch;
 pub use configure::configure;
 pub use create::create;
 pub use delete::delete;
-pub use info::{info, info_md};
 pub use list::list;
 pub use switch::switch;
 

--- a/src/subcommands/profile/switch.rs
+++ b/src/subcommands/profile/switch.rs
@@ -1,5 +1,6 @@
 use crate::THEME;
 use anyhow::{anyhow, Result};
+use colored::Colorize;
 use dialoguer::Select;
 use libium::config::structs::Config;
 
@@ -22,7 +23,12 @@ pub fn switch(config: &mut Config, profile_name: Option<String>) -> Result<()> {
         let profile_names = config
             .profiles
             .iter()
-            .map(|profile| &profile.name)
+            .map(|profile| {
+                format!(
+                    "{:6} {:8} {}",
+                    format!("{:?}", profile.mod_loader), profile.game_version, profile.name.bold()
+                )
+            })
             .collect::<Vec<_>>();
 
         let selection = Select::with_theme(&*THEME)

--- a/src/subcommands/remove.rs
+++ b/src/subcommands/remove.rs
@@ -1,8 +1,7 @@
-use crate::THEME;
+use crate::{get_oneline_mod_info, THEME};
 use anyhow::{bail, Result};
 use colored::Colorize;
 use dialoguer::MultiSelect;
-use itertools::Itertools;
 use libium::config::structs::{ModIdentifier, Profile};
 
 /// If `to_remove` is empty, display a list of projects in the profile to select from and remove selected ones
@@ -52,13 +51,13 @@ pub fn remove(profile: &mut Profile, to_remove: Vec<String>) -> Result<()> {
 
     let mut removed = Vec::new();
     for index in indices_to_remove {
-        removed.push(profile.mods.swap_remove(index).name);
+        removed.push(profile.mods.swap_remove(index));
     }
 
-    println!(
-        "Removed {}",
-        removed.iter().map(|txt| txt.bold()).format(", ")
-    );
+    println!("{}", "Removed:".red());
+    for mod_ in removed {
+        println!("  {}", get_oneline_mod_info(&mod_));
+    }
 
     Ok(())
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -307,3 +307,21 @@ fn delete_modpack() -> Result {
         Some("two_modpacks_mdactive"),
     )
 }
+
+// A Test that checks the info subcommand
+#[test]
+fn profile_info() -> Result {
+    run_command(
+        vec!["profile", "info"],
+        Some("one_profile_full"),
+    )
+}
+
+// A Test that checks the info subcommand for modpacks
+#[test]
+fn modpack_info() -> Result {
+    run_command(
+        vec!["modpack", "info"],
+        Some("two_modpacks_mdactive"),
+    )
+}


### PR DESCRIPTION
Partially implemented #250 

- [x] ~~`ferium info` should show information about the current profile and modpack~~
  - [x] `ferium profile info` added instead to be more scoped 
  - [x] `ferium modpack info` info should be added in a similar manner
- [x] `ferium profile list` - tweaked the active profile indicator to be bold green `(active)` suffix next to profile name.
- [x] When `ferium add` fails, ~~link to documentation about overrides (https://github.com/gorilla-devs/ferium#check-overrides)~~ hint about `--dont-check-*` flags as part of the error message.
- [x] ~~`ferium profile` should print the current profile, then Run `ferium profile -h` for more info about this command (likewise for ferium modpack too)~~ instead use `ferium profile info` to align with current usage patterns
- [x] `ferium list` should print a header with information about the profile about to be listed (i.e. profile name, loader, and mc version) as well
  - [x] added support for `--markdown` flag in the `ferium list -vm` variant
- [x] `ferium profile switch` should print more info about the profiles, not just the names 
  - [x] ~~likewise for `ferium modpack switch`~~ no need for that
- [x] `ferium profiles` should be an alias to `ferium profile list` (likewise for `ferium modpacks` too)
- [x] `ferium mods` should be an alias to `ferium list`
- [x] `ferium remove` should print the project id of the removed mods too
