### PR TITLE
Remove mods by their slugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,7 @@ checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 [[package]]
 name = "libium"
 version = "1.32.0"
-source = "git+https://github.com/gorilla-devs/libium?rev=e043a6e17a475158a595cfcf1767ef81521d0587#e043a6e17a475158a595cfcf1767ef81521d0587"
+source = "git+https://github.com/gorilla-devs/libium?rev=425a043553f42e2872a70f193cd5042effce561a#425a043553f42e2872a70f193cd5042effce561a"
 dependencies = [
  "clap",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,7 +1468,7 @@ checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
 [[package]]
 name = "libium"
 version = "1.32.0"
-source = "git+https://github.com/gorilla-devs/libium?rev=425a043553f42e2872a70f193cd5042effce561a#425a043553f42e2872a70f193cd5042effce561a"
+source = "git+https://github.com/gorilla-devs/libium?rev=eed35ae6b695a93b9e26b59974a2b26fe3ac7407#eed35ae6b695a93b9e26b59974a2b26fe3ac7407"
 dependencies = [
  "clap",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ fs_extra = "1.3"
 ferinth = "2.11"
 colored = "3.0"
 inquire = "0.7"
-libium = { git = "https://github.com/gorilla-devs/libium", rev = "425a043553f42e2872a70f193cd5042effce561a" }
+libium = { git = "https://github.com/gorilla-devs/libium", rev = "eed35ae6b695a93b9e26b59974a2b26fe3ac7407" }
 # libium = { path = "../libium" }
 # libium = "1.32"
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ fs_extra = "1.3"
 ferinth = "2.11"
 colored = "3.0"
 inquire = "0.7"
-libium = { git = "https://github.com/gorilla-devs/libium", rev = "e043a6e17a475158a595cfcf1767ef81521d0587" }
+libium = { git = "https://github.com/gorilla-devs/libium", rev = "425a043553f42e2872a70f193cd5042effce561a" }
 # libium = { path = "../libium" }
 # libium = "1.32"
 anyhow = "1.0"

--- a/src/subcommands/list.rs
+++ b/src/subcommands/list.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinSet;
 enum Metadata {
     CF(Mod),
     MD(Project, Vec<TeamMember>),
-    GH(Repository, Vec<Release>),
+    GH(Box<Repository>, Vec<Release>),
 }
 impl Metadata {
     fn name(&self) -> &str {
@@ -100,7 +100,7 @@ pub async fn verbose(profile: &mut Profile, markdown: bool) -> Result<()> {
     }
     for res in tasks.join_all().await {
         let (repo, releases) = res?;
-        metadata.push(Metadata::GH(repo, releases.items));
+        metadata.push(Metadata::GH(Box::new(repo), releases.items));
     }
     metadata.sort_unstable_by_key(|e| e.name().to_lowercase());
 

--- a/src/subcommands/list.rs
+++ b/src/subcommands/list.rs
@@ -35,6 +35,14 @@ impl Metadata {
             }
         }
     }
+
+    fn slug(&self) -> &str {
+        match self {
+            Metadata::CF(p) => &p.slug,
+            Metadata::MD(p, _) => &p.slug,
+            Metadata::GH(p, _) => &p.name,
+        }
+    }
 }
 
 pub async fn verbose(profile: &mut Profile, markdown: bool) -> Result<()> {
@@ -101,12 +109,14 @@ pub async fn verbose(profile: &mut Profile, markdown: bool) -> Result<()> {
     }
 
     for project in &metadata {
-        profile
+        let mod_ = profile
             .mods
             .iter_mut()
             .find(|mod_| mod_.identifier == project.id())
-            .context("Could not find expected mod")?
-            .name = project.name().to_string();
+            .context("Could not find expected mod")?;
+
+        mod_.name = project.name().to_string();
+        mod_.slug = Some(project.slug().to_string());
 
         if markdown {
             match project {

--- a/src/subcommands/remove.rs
+++ b/src/subcommands/remove.rs
@@ -51,6 +51,10 @@ pub fn remove(profile: &mut Profile, to_remove: Vec<String>) -> Result<()> {
                         }
                         _ => todo!(),
                     }
+                    || match &mod_.slug {
+                        Some(slug) => to_remove.eq_ignore_ascii_case(slug),
+                        None => false,
+                    }
             }) {
                 items_to_remove.push(index);
             } else {

--- a/src/subcommands/remove.rs
+++ b/src/subcommands/remove.rs
@@ -51,10 +51,10 @@ pub fn remove(profile: &mut Profile, to_remove: Vec<String>) -> Result<()> {
                         }
                         _ => todo!(),
                     }
-                    || match &mod_.slug {
-                        Some(slug) => to_remove.eq_ignore_ascii_case(slug),
-                        None => false,
-                    }
+                    || mod_
+                        .slug
+                        .as_ref()
+                        .is_some_and(|slug| to_remove.eq_ignore_ascii_case(slug))
             }) {
                 items_to_remove.push(index);
             } else {


### PR DESCRIPTION
Adds support for removing mods by their slugs, fetches and updates the stored slugs for older configs when running `ferium list --verbose`

Dependent on gorilla-devs/libium#22

Fixes #439 