### PR TITLE
Fix compilation of `libium`

### DIFF
--- a/libium/Cargo.toml
+++ b/libium/Cargo.toml
@@ -37,3 +37,7 @@ regex = "1.11"
 sha1 = "0.10"
 home = "0.5"
 zip = "2.5"
+
+[patch.crates-io]
+# Fix https://github.com/matzefriedrich/zip-extensions-rs/pull/19
+zip-extensions = { git = "https://github.com/andriipopazov/zip-extensions-rs", rev = "c3556d757574d4d00ee65a3f0c726b45ba44876f" }


### PR DESCRIPTION
`libium` cannot be compiled currently (or at least, `cargo install`ed without freezing the lock), because of an issue in `zip-extensions-rs`. This PR patches the dependency with https://github.com/matzefriedrich/zip-extensions-rs/pull/19 to fix the issue quickly, since upstream seems pretty inactive (last commit 7 months ago).