### PR TITLE
Fix: Add HTTP error handling to prevent download hangs

### DIFF
--- a/libium/src/upgrade/mod.rs
+++ b/libium/src/upgrade/mod.rs
@@ -284,6 +284,7 @@ impl DownloadData {
         );
 
         let mut response = client.get(url).send().await?;
+        response.error_for_status_ref()?;
 
         while let Some(chunk) = response.chunk().await? {
             temp_file.write_all(&chunk)?;


### PR DESCRIPTION
## Problem
Downloads would hang indefinitely at 0 B/s when the server returned HTTP error responses.

## Solution
Added `response.error_for_status_ref()?` to check HTTP status codes before attempting to read response chunks.

## idunno
I'm not sure why this worked, but my best guess would be that the error handling just re-requested the site downloads and allowed the download to take place.

## Testing
Successfully tested with a 510MB modpack download (258 files) that previously hung.